### PR TITLE
Add const validation

### DIFF
--- a/check-notebooks.py
+++ b/check-notebooks.py
@@ -19,6 +19,9 @@ def const_structured_check(astnode) -> bool:
     if isinstance(astnode, (ast.Constant, ast.Num, ast.Str)):
         return True
 
+    if isinstance(astnode, ast.UnaryOp) and isinstance(astnode.op, ast.USub):
+        return isinstance(astnode.operand, (ast.Constant, ast.Num)) and isinstance(astnode.operand.n, int)
+
     if isinstance(astnode, (ast.List, ast.Set, ast.Tuple)):
         return all(const_structured_check(elt) for elt in astnode.elts)
 


### PR DESCRIPTION
I've introduced constant validation, allowing you to dynamically include constant variables in the workflow file. For instance, if you wish to include constants `[x, y, test_var, comment]`, you can do so by adding the following configuration:
```yml
- name: Check Syntax
  uses: JanezSedeljsak/homework-actions@main
  with:
    args: 'x y test_var comment'
```

In case you have a notebook file like this:
![image](https://github.com/IB-ULFRI/homework-actions/assets/43420276/a9946f10-3602-4d73-93e0-e9c918237e49)
As you can see from the notebook we only look at the most bottom decleration. The pipeline will now trigger an error message: 'ValueError: Invalid constant: 'comment'!'."

<b>Maybe you could add a new branch like `constant-check` so that this action can be separate from the old one.</b>
@MartinSpendl @pavlin-policar